### PR TITLE
fix: install sigfig dependency in vs-prep image

### DIFF
--- a/Dockerfile-prep
+++ b/Dockerfile-prep
@@ -19,7 +19,8 @@ WORKDIR ${HOME}
 RUN pip install scikit-learn==1.2.2\
   pdb2pqr==3.6.1\
   im-standardize-molecule==0.1.0\
-  im-data-manager-job-utilities==1.1.1
+  im-data-manager-job-utilities==1.1.1\
+  sigfig==1.3.19
 
 COPY *.py fpscores.pkl.gz site_substructures.smarts ./
 COPY moldb/* ./moldb/


### PR DESCRIPTION
## Summary
- `sa_score.py` imports `sigfig` (`from sigfig import round`), but `Dockerfile-prep` never installs it, so the `rdkit`/`sa-score` job fails at runtime with `ModuleNotFoundError: No module named 'sigfig'`.
- Adds `sigfig==1.3.19` to the pinned pip install list, matching the style of the other dependencies in that layer.

Found while running the full jote test suite for this repo — this was the only real (non-environmental) test failure among the 32 tests in `manifest-im-virtual-screening.yaml`.

## Test plan
- [x] Rebuilt `informaticsmatters/vs-prep:stable` locally with the fix
- [x] `jote --manifest data-manager/manifest-im-virtual-screening.yaml -c rdkit -j sa-score` → SUCCESS (was previously failing with `ModuleNotFoundError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)