### PR TITLE
fix: rename minValue/maxValue to minimum/maximum in moldb.yaml

### DIFF
--- a/data-manager/moldb.yaml
+++ b/data-manager/moldb.yaml
@@ -271,8 +271,8 @@ jobs:
             title: Chunk size for splitting
             type: integer
             default: 100000
-            minValue: 10000
-            maxValue: 1000000
+            minimum: 10000
+            maximum: 1000000
     tests:
       simple-load:
         nextflow-config-file: nextflow-moldb.config
@@ -352,13 +352,13 @@ jobs:
             title: Max number of molecules to process
             type: integer
             default: 1000000
-            maxValue: 5000000
+            maximum: 5000000
           chunk_size:
             title: Chunk size for splitting
             type: integer
             default: 50000
-            minValue: 10000
-            maxValue: 1000000
+            minimum: 10000
+            maximum: 1000000
     tests:
       simple-calc:
         nextflow-config-file: nextflow-moldb.config
@@ -451,13 +451,13 @@ jobs:
             title: Max number of molecules to process
             type: integer
             default: 100000
-            maxValue: 5000000
+            maximum: 5000000
           chunk_size:
             title: Chunk size for splitting
             type: integer
             default: 10000
-            minValue: 10000
-            maxValue: 1000000
+            minimum: 10000
+            maximum: 1000000
     tests:
       simple-enum:
         nextflow-config-file: nextflow-moldb.config
@@ -549,13 +549,13 @@ jobs:
             title: Max number of molecules to process
             type: integer
             default: 100000
-            maxValue: 5000000
+            maximum: 5000000
           chunk_size:
             title: Chunk size for splitting
             type: integer
             default: 10000
-            minValue: 10000
-            maxValue: 1000000
+            minimum: 10000
+            maximum: 1000000
     tests:
       simple-confs:
         nextflow-config-file: nextflow-moldb.config
@@ -768,7 +768,7 @@ jobs:
             title: Max number of molecules to extract
             type: integer
             default: 100000
-            maxValue: 5000000
+            maximum: 5000000
           incl_taut:
             title: Include tautomers
             type: boolean
@@ -897,7 +897,7 @@ jobs:
             title: Max number of molecules to extract
             type: integer
             default: 100000
-            maxValue: 5000000
+            maximum: 5000000
           incl_taut:
             title: Include tautomers
             type: boolean


### PR DESCRIPTION
## Summary
- `data-manager/moldb.yaml` still used the old `minValue`/`maxValue` keys, which the job-definition schema no longer accepts (only `minimum`/`maximum` are valid). #14 renamed these across the other job definitions but missed this file.
- As a result `jote --manifest data-manager/manifest-moldb.yaml` failed schema validation before any test could even be discovered (and this is why CI's `test.yaml` workflow excludes this manifest from its `jote --dry-run` list).
- Renames all 13 occurrences to `minimum`/`maximum`.

## Test plan
- [x] `jote --manifest data-manager/manifest-moldb.yaml --dry-run --allow-no-tests` → now finds and dry-run-passes all 12 tests (previously failed with `Additional properties are not allowed ('maxValue', 'minValue' were unexpected)`)
- [ ] Full (non-dry-run) execution requires a Postgres instance (see `docker-compose-postgres.yaml`) — not exercised here

🤖 Generated with [Claude Code](https://claude.com/claude-code)