### PR TITLE
fix: correct rDock Job display name typo ("rRock" -> "rDock")

### DIFF
--- a/data-manager/im-virtual-screening.yaml
+++ b/data-manager/im-virtual-screening.yaml
@@ -937,7 +937,7 @@ jobs:
   # nextflow jobs
   ####################
   run-rdock:
-    name: Run rRock docking
+    name: Run rDock docking
     description: >-
       Run rDock docking.
     version: '1.0.0'


### PR DESCRIPTION
## What

The `run-rdock` Job Definition in `data-manager/im-virtual-screening.yaml` had a
typo in its display name:

```diff
-    name: Run rRock docking
+    name: Run rDock docking
```

## Why

The name is user-facing (shown in the Data Manager UI). "rRock" should be
"rDock", the name of the docking tool the Job runs.

## Scope

Display-name only — no change to the command, image, variables, or tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)