### PR TITLE
fix: pin numpy<2 in rdkit-base and dmpk images

### DIFF
--- a/Dockerfile-dmpk
+++ b/Dockerfile-dmpk
@@ -16,7 +16,9 @@ ENV PYTHONPATH=/code
 ENV HOME=/code
 WORKDIR ${HOME}
 
-RUN pip install matplotlib==3.7.1 im-data-manager-job-utilities==1.0.1
+# numpy is pinned below 2 because this matplotlib release predates
+# NumPy 2.0 and its compiled extensions are not ABI-compatible with it
+RUN pip install "numpy<2" matplotlib==3.7.1 im-data-manager-job-utilities==1.0.1
 
 COPY utils.py ./
 COPY dmpk/*.py ./dmpk/

--- a/Dockerfile-rdkit-base
+++ b/Dockerfile-rdkit-base
@@ -13,6 +13,8 @@ RUN apt-get -y update &&\
 ENV PYTHONUNBUFFERED=1
 
 # pip install RDKit
-RUN pip install rdkit==2023.3.2
+# numpy is pinned below 2 because this rdkit release predates NumPy 2.0
+# and its compiled extensions are not ABI-compatible with it
+RUN pip install "numpy<2" rdkit==2023.3.2
 
 


### PR DESCRIPTION
## Summary
- `Dockerfile-rdkit-base` (`rdkit==2023.3.2`) and `Dockerfile-dmpk` (`matplotlib==3.7.1`) both predate NumPy 2.0 (released June 2024) and ship compiled extensions built against NumPy's 1.x C-API.
- Neither Dockerfile pins `numpy`, so a rebuild today silently resolves the latest NumPy (2.2.6) as a transitive dependency, breaking those older compiled extensions at import time with `AttributeError: _ARRAY_API not found`.
- This was hitting `pk-tmax-cmax-sim` (via matplotlib) and both `descriptor-generator` tests in `manifest-im-mordred.yaml` (via rdkit/mordred, which inherits from `vs-rdkit-base`).
- Fix: explicitly pin `numpy<2` alongside the affected packages in both Dockerfiles.

Found while running a full (non-dry-run) `jote` pre-refactor health check across all job submodules in `squonk2-jobs`.

**Note:** `informaticsmatters/vs-rdkit-base` is built and pushed to Docker Hub manually, outside CI (per the repo README), so this fix needs someone with push access to rebuild and republish `vs-rdkit-base:latest` after merge — CI alone won't propagate it to jobs that build `FROM` that base image.

## Test plan
- [x] Rebuilt `vs-rdkit-base`, `vs-dmpk:stable`, and `mordred:stable` locally with the pin in place — confirmed `numpy==1.26.4` resolves in both images.
- [x] `jote --manifest manifest-dmpk.yaml --allow-no-tests` (real execution) — `pk-tmax-cmax-sim/simple-execution` now passes.
- [x] `jote --manifest manifest-im-mordred.yaml --allow-no-tests` (real execution) — both `descriptor-generator` tests (`execution-2d`, `execution-3d`) now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)