### PR TITLE
fix: bump im-data-manager-job-utilities to 1.3.0

### DIFF
--- a/Dockerfile-jaqpot
+++ b/Dockerfile-jaqpot
@@ -4,7 +4,7 @@ RUN apt-get -y update &&\
   apt-get -y install procps &&\
   apt-get clean
 
-RUN pip install im-data-manager-job-utilities==1.0.1 im-rdkit-utilities==1.0.0
+RUN pip install im-data-manager-job-utilities==1.3.0 im-rdkit-utilities==1.0.0
 
 ENV HOME=/code
 WORKDIR ${HOME}

--- a/Dockerfile-moldb
+++ b/Dockerfile-moldb
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y gcc libpq-dev &&\
 RUN pip install sqlalchemy==1.4.49\
     psycopg2-binary==2.9.6\
     im-standardize-molecule==0.1.0\
-    im-data-manager-job-utilities==1.0.1\
+    im-data-manager-job-utilities==1.3.0\
     im-rdkit-utilities==1.0.0
 
 COPY *.py site_substructures.smarts ./

--- a/Dockerfile-mordred
+++ b/Dockerfile-mordred
@@ -13,7 +13,7 @@ WORKDIR ${HOME}
 # install our requirements. RDKit is present in base container
 RUN pip install mordredcommunity==2.0.4 \
   im-standardize-molecule==0.1.0 \
-  im-data-manager-job-utilities==1.1.1 \
+  im-data-manager-job-utilities==1.3.0 \
   im-rdkit-utilities==1.0.0
 
 COPY im_mordred/descriptor_generator.py ./im_mordred/

--- a/Dockerfile-oddt
+++ b/Dockerfile-oddt
@@ -15,7 +15,7 @@ ENV HOME=/code
 WORKDIR ${HOME}
 
 RUN pip install wheel six &&\
-  pip install im-data-manager-job-utilities==1.1.1\
+  pip install im-data-manager-job-utilities==1.3.0\
   im-rdkit-utilities==1.0.0\
   git+https://github.com/oddt/oddt.git@master
 

--- a/Dockerfile-prep
+++ b/Dockerfile-prep
@@ -19,7 +19,7 @@ WORKDIR ${HOME}
 RUN pip install scikit-learn==1.2.2\
   pdb2pqr==3.6.1\
   im-standardize-molecule==0.1.0\
-  im-data-manager-job-utilities==1.1.1\
+  im-data-manager-job-utilities==1.3.0\
   im-rdkit-utilities==1.0.0\
   sigfig==1.3.19
 


### PR DESCRIPTION
## Summary
Follow-up to #21. `im-rdkit-utilities==1.0.0` hard-pins `im-data-manager-job-utilities==1.3.0`, which conflicted with these Dockerfiles' older pins (`1.1.1`/`1.0.1`) and broke the build entirely (`ResolutionImpossible`) — not caught in #21 because the images weren't rebuilt locally at review time.

## Test plan
- [x] `Dockerfile-mordred`, `Dockerfile-moldb`, `Dockerfile-oddt` all build cleanly now
- [x] `jote` passes for the mordred collection (2/2) and moldb's non-nextflow jobs
- [x] Direct check that `rdkit_utils.updateChargeFlagInAtomBlock` (used by `moldb/enumerate.py`/`moldb/filter.py`) still produces correct output
- [ ] `Dockerfile-prep`'s build is separately blocked by an **unrelated, pre-existing** issue: its `apt-get install openbabel python3-openbabel` step pulls from `bullseye-security`, which has since pruned those package builds from the mirror. Confirmed this also fails identically checking out the pre-migration `Dockerfile-prep` — not something this change introduced. Verified prep's pip resolution (the part this PR actually touches) succeeds cleanly in isolation. Flagging since I couldn't get a full jote run for the prep-based jobs (`open3dalign`, `sucos`, `assemble_conformers`, `cluster_butina`, `enumerate`, `le_conformers`, `rdkit_dedup`, `rdkit_props`, `screen`, `reactor`) as a result.

Part of #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)