### PR TITLE
fix: apt-get update before installing openbabel in Dockerfile-prep

### DIFF
--- a/Dockerfile-prep
+++ b/Dockerfile-prep
@@ -8,7 +8,11 @@ FROM informaticsmatters/vs-rdkit-base:latest
 
 # openbabel does not install easily with PIP, and we don't have conda so we must use apt to install.
 # this installs version 3.1.1
-RUN apt-get -y install openbabel python3-openbabel &&\
+# apt-get update is required here (rather than relying on the base image's
+# package index) because the bullseye-security mirror periodically prunes
+# superseded point-release .debs, leaving a stale index full of 404s.
+RUN apt-get -y update &&\
+  apt-get -y install openbabel python3-openbabel &&\
   apt-get clean
 
 ENV PYTHONPATH=/code


### PR DESCRIPTION
## Summary
`Dockerfile-prep` never ran `apt-get update` itself — it relied on the package index baked into `informaticsmatters/vs-rdkit-base:latest` at base-image build time. `bullseye-security` periodically prunes superseded point-release `.deb`s, so that stale index eventually points at files that no longer exist, and the build starts failing with 404s. This was blocking `jote` for `open3dalign`, `sucos`, `assemble_conformers`, `cluster_butina`, `enumerate`, `le_conformers`, `rdkit_dedup`, `rdkit_props`, `sa_score`, `screen` and `reactor` after #21/#22 — confirmed it also fails identically on pre-migration code, so it's unrelated to the `im-rdkit-utilities` migration itself, just something that surfaced while verifying it.

No version is pinned for `openbabel`/`python3-openbabel` here, so a fresh `apt-get update` resolves to whatever build is currently on the mirror instead (still `3.1.1+dfsg-6`, just resolved fresh rather than from a stale cached index).

## Test plan
- [x] Image builds cleanly
- [x] Full `im-virtual-screening`/`rdkit`/`xchem` `jote` suite passes **32/32** (with `NXF_VER=22.10.0` per `docs/testing-jobs.md`, needed for the nextflow-based jobs in the same suite — unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)