### PR TITLE
chore: invoke migrated Jobs via the -i/-o short options

### DIFF
--- a/data-manager/im-virtual-screening.yaml
+++ b/data-manager/im-virtual-screening.yaml
@@ -725,7 +725,7 @@ jobs:
     name: Enumerate microstates, tautomers and undefined chiral centres
     description: >-
       Enumerate microstates, tautomers and undefined chiral centres.
-    version: '1.0.0'
+    version: '1.0.1'
     category: virtual screening
     keywords:
     - rdkit
@@ -740,7 +740,7 @@ jobs:
       working-directory: /data
       fix-permissions: true
     command: >-
-      /code/enumerate.py --input '{{ inputFile }}' --output '{{ outputFile }}'
+      /code/enumerate.py -i '{{ inputFile }}' -o '{{ outputFile }}'
       {% if fragment is defined %}--fragment-method '{{ fragment }}'{% endif %}
       {% if enumerateCharges is defined and enumerateCharges %}--enumerate-charges{% endif %}
       {% if enumerateChirals is defined and enumerateChirals %}--enumerate-chirals{% endif %}

--- a/data-manager/rdkit.yaml
+++ b/data-manager/rdkit.yaml
@@ -114,7 +114,7 @@ jobs:
   generate-low-energy-conformers:
     name: Generate 3D conformers
     description: Generate a low energy 3D conformers of molecules
-    version: '1.0.0'
+    version: '1.0.1'
     category: virtual screening
     keywords:
     - rdkit
@@ -128,7 +128,7 @@ jobs:
       working-directory: /data
       fix-permissions: true
     command: >-
-      /code/le_conformers.py --input '{{ inputFile }}' --output '{{ outputFile }}'
+      /code/le_conformers.py -i '{{ inputFile }}' -o '{{ outputFile }}'
       {% if fragment is defined %}--fragment-method '{{ fragment }}'{% endif %}
       {% if numConformers is defined %}--num-conformers {{ numConformers }}{% endif %}
       {% if minimizeCycles is defined %}--minimize-cycles {{ minimizeCycles }}{% endif %}
@@ -469,7 +469,7 @@ jobs:
     name: Molecular property calculations
     description: >-
       Calculates molecular properties using RDKit
-    version: '1.0.0'
+    version: '1.0.1'
     category: molecular properties
     keywords:
     - rdkit
@@ -481,8 +481,8 @@ jobs:
       working-directory: /data
       fix-permissions: true
     command: >-
-      /code/rdkit_props.py --input '{{ inputFile }}'
-      --outfile '{{ outputFile }}'
+      /code/rdkit_props.py -i '{{ inputFile }}'
+      -o '{{ outputFile }}'
       {% if hac is defined and hac %}--hac{% endif %}
       {% if numRotBonds is defined and numRotBonds %}--num-rot-bonds{% endif %}
       {% if numRings is defined and numRings %}--num-rings{% endif %}
@@ -685,7 +685,7 @@ jobs:
     name: Deduplicate molecules
     description: >-
       Deduplicate molecules using RDKit
-    version: '1.0.1'
+    version: '1.0.2'
     category: molecular properties
     keywords:
     - rdkit
@@ -697,8 +697,8 @@ jobs:
       working-directory: /data
       fix-permissions: true
     command: >-
-      /code/rdkit_dedup.py --input '{{ inputFile }}'
-      --outfile '{{ outputFile }}'
+      /code/rdkit_dedup.py -i '{{ inputFile }}'
+      -o '{{ outputFile }}'
       {% if mode is defined and mode %}--mode {{ mode }}{% endif %}
       {% if minHac is defined %}--min-hac {{ minHac }}{% endif %}
       {% if maxHac is defined %}--max-hac {{ maxHac }}{% endif %}
@@ -828,7 +828,7 @@ jobs:
     name: Synthetic accessibility score
     description: >-
       Calculates a synthetic accessibility score based on the approach of Ertl and Schuffenhauer
-    version: '1.0.0'
+    version: '1.0.1'
     category: molecular properties
     keywords:
     - rdkit
@@ -841,8 +841,8 @@ jobs:
       working-directory: /data
       fix-permissions: true
     command: >-
-      /code/sa_score.py --input '{{ inputFile }}'
-      --outfile '{{ outputFile }}'
+      /code/sa_score.py -i '{{ inputFile }}'
+      -o '{{ outputFile }}'
       {% if readHeader is defined and readHeader %}--read-header{% endif %}
       {% if writeHeader is defined and writeHeader %}--write-header{% endif %}
       {% if separator is defined %}--delimiter '{{ separator }}'{% endif %}
@@ -944,7 +944,7 @@ jobs:
       Filters molecules by molecular similarity using RDKit.
       A number of descriptors and metrics are available.
       Query molecule(s) are specified from a project file or as SMILES.
-    version: '1.0.0'
+    version: '1.0.1'
     category: comp chem
     keywords:
     - rdkit
@@ -960,9 +960,9 @@ jobs:
       working-directory: /data
       fix-permissions: true
     command: >-
-      /code/screen.py --input '{{ inputFile }}'
+      /code/screen.py -i '{{ inputFile }}'
       --queries-file '{{ queries }}'
-      --output '{{ outputFileName }}'
+      -o '{{ outputFileName }}'
       {% if headerInputs is defined %}--read-header{% endif %}
       {% if headerQueries is defined %}--queries-read-header{% endif %}
       {% if headerOutputs is defined %}--write-header{% endif %}
@@ -1380,7 +1380,7 @@ jobs:
     name: Butina Clustering
     description: >-
       Cluster molecules with Butina and RDKit fingerprints
-    version: '1.0.0'
+    version: '1.0.1'
     category: comp chem
     keywords:
     - rdkit
@@ -1394,8 +1394,8 @@ jobs:
       working-directory: /data
       fix-permissions: true
     command: >-
-      /code/cluster_butina.py --input '{{ inputFile }}'
-      --output {{ outputFile }}
+      /code/cluster_butina.py -i '{{ inputFile }}'
+      -o {{ outputFile }}
       {% if readHeader is defined and readHeader %}--read-header{% endif %}
       {% if writeHeader is defined and writeHeader %}--write-header{% endif %}
       {% if separator is defined %}--delimiter {{ separator }}{% endif %}


### PR DESCRIPTION
Closes the Job Definition half of InformaticsMatters/squonk2-jobs#39.

## What changed

Seven Jobs invoke scripts that now build their I/O options from
`rdkit_utils.add_common_molecule_io_args()`. Their command blocks moved from
`--input`/`--output` to **`-i`/`-o`**, and their Job Definition versions are
bumped per `docs/versioning.md`.

| File | Job | Script | Version |
| ---- | --- | ------ | ------- |
| `rdkit.yaml` | `generate-low-energy-conformers` | `le_conformers.py` | 1.0.0 → 1.0.1 |
| `rdkit.yaml` | `rdkit-molprops` | `rdkit_props.py` | 1.0.0 → 1.0.1 |
| `rdkit.yaml` | `rdkit-dedup` | `rdkit_dedup.py` | 1.0.1 → 1.0.2 |
| `rdkit.yaml` | `sa-score` | `sa_score.py` | 1.0.0 → 1.0.1 |
| `rdkit.yaml` | `similarity-screen-rdkit` | `screen.py` | 1.0.0 → 1.0.1 |
| `rdkit.yaml` | `cluster-butina` | `cluster_butina.py` | 1.0.0 → 1.0.1 |
| `im-virtual-screening.yaml` | `enumerate-candidates` | `enumerate.py` | 1.0.0 → 1.0.1 |

## Why the short forms, not `--infile`/`--outfile`

Issue #39 asked for the canonical *long* spellings. I tried that first and
`jote` failed 11 of 32 tests:

```
enumerate.py: error: the following arguments are required: -i/--input, -o/--output
rdkit_props.py: error: the following arguments are required: -i/--input
```

Every Job in this manifest pins `tag: 'stable'`, and
`informaticsmatters/vs-prep:stable` was last published on **2024-06-10** — long
before the migration. It has no `--infile`/`--outfile` at all. So a definition
written with the long spellings cannot be loaded until a new image is published,
which turns a cosmetic change into a release-ordering problem.

`-i` and `-o` are canonical too, and they are the only spelling that works
against *both* the pre-migration image and the migrated code — and they survive
the eventual removal of the `--input`/`--output` aliases without a second pass.
They are also already how `squonk2-desc-mordred`, `squonk2-desc-rdkit` and
`squonk2-train-test-split` invoke their migrated scripts.

## Verification

`jote -m data-manager/manifest-im-virtual-screening.yaml`, nextflow 22.10.0 to
match `Dockerfile-nextflow`:

- against the published `vs-prep:stable` — `found=32 passed=32 failed=0`
- against a locally built `:latest` carrying the migrated scripts, for the 7
  changed Jobs via `--image-tag latest` — `found=11 passed=11 failed=0`

The second run is the first time `jote` has exercised the migrated
virtual-screening scripts: the earlier post-migration run passed entirely on the
published 2024 image, so it validated the old code.

## Deliberately unchanged

`max_min_picker`, `le_conformers_for_mol`, `reactor`, `sucos`, `fail`,
`prepare_rdock`, `pharmacophore`, `convert_file`, `sdf_manip` and the `moldb`
modules declare `--input`/`--output` themselves and never adopted the shared
group — renaming them would be a gratuitous breaking change. The
`--input`/`--output` on the two nextflow Jobs are `params.input`/`params.output`
for `le_conformers.nf` and `enumerate.nf`; both workflows already call their
scripts with `-i`/`-o`. `cluster-butina`'s `--output-fragment` is its own flag.

Note that #39's scope table mislabels `rdkit.yaml` lines 1631–1632 as
`cluster_butina.py`; that command is `python -m sdf_manip`, which is out of
scope. The real scope was 7 Jobs, not 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)