### PR TITLE
docs: use -i/-o in screen.py examples

### DIFF
--- a/frag-merge.md
+++ b/frag-merge.md
@@ -38,7 +38,7 @@ tht mean they will be reasonably 'lead like'.
 ## Find similar molecules
 
 ```
-./screen.py --smiles 'CC(=O)NC1=CN=CC=C1C' 'CC(NC(=O)C)c1cccc(Cl)c1' --input frag-merge/mols.smi --output frag-merge/screened.smi --metric tversky --descriptor morgan2 --nbits 1024 --interval 10000 --sim-index 5 --threshold 0.3
+./screen.py --smiles 'CC(=O)NC1=CN=CC=C1C' 'CC(NC(=O)C)c1cccc(Cl)c1' -i frag-merge/mols.smi -o frag-merge/screened.smi --metric tversky --descriptor morgan2 --nbits 1024 --interval 10000 --sim-index 5 --threshold 0.3
 ...
 ...
 2021-11-06T13:47:09+00:00 # INFO -EVENT- Processed 4560000 records, 4362 hits

--- a/screen.py
+++ b/screen.py
@@ -273,9 +273,9 @@ def execute(query_smis,
 def main():
 
     # Examples:
-    #   python screen.py --smiles 'O=C(Nc1ccc(Cl)cc1)c1ccccn1' --input data/10000.smi --delimiter tab -o foo.smi\
+    #   python screen.py --smiles 'O=C(Nc1ccc(Cl)cc1)c1ccccn1' -i data/10000.smi --delimiter tab -o foo.smi\
     #     --descriptor rdkit -m tanimoto
-    #   python screen.py --queries-file data/10.smi --input data/10000.smi --delimiter tab --id-column 1 -o foo.smi \
+    #   python screen.py --queries-file data/10.smi -i data/10000.smi --delimiter tab --id-column 1 -o foo.smi \
     #     --descriptor rdkit -m tanimoto --queries-delimiter tab --threshold 0.4
 
     parser = argparse.ArgumentParser(description='screen')


### PR DESCRIPTION
The usage comments in `screen.py` and the `frag-merge.md` walkthrough invoke
`screen.py` with `--input`/`--output`. Those are deprecated aliases on the
shared molecule I/O group, due to be withdrawn in
InformaticsMatters/squonk2-rdkit-utilities#5.

The Job Definitions moved to `-i`/`-o` in #27, so the examples should match.
Comments only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)