### PR TITLE
fix: move similarity-screen-rdkit 'derived-from' to annotation-properties

### DIFF
--- a/data-manager/rdkit.yaml
+++ b/data-manager/rdkit.yaml
@@ -944,7 +944,7 @@ jobs:
       Filters molecules by molecular similarity using RDKit.
       A number of descriptors and metrics are available.
       Query molecule(s) are specified from a project file or as SMILES.
-    version: '1.0.1'
+    version: '1.0.2'
     category: comp chem
     keywords:
     - rdkit
@@ -1048,7 +1048,7 @@ jobs:
                       Geometric mean of similarities
                     required: true
                     active: true
-                derived-from: inputFile
+              derived-from: inputFile
       options:
         type: object
         required:


### PR DESCRIPTION
## What broke

`im-data-manager-job-decoder` **2.7.0** was released on 2026-08-13 and immediately
turned CI red in the
[squonk2-jobs umbrella repo](https://github.com/InformaticsMatters/squonk2-jobs):

```
! Job definition "data-manager/rdkit.yaml" does not comply with schema
Additional properties are not allowed ('derived-from' was unexpected)
```

## It is a real bug, not a schema regression

`derived-from` is legitimate and **supported** — 2.7.0 makes it a first-class
property of the new `annotation-properties` definition. Only its *placement* here
was wrong. In `similarity-screen-rdkit` it sits one level too deep, inside
`fields-descriptor`:

```
jobs.similarity-screen-rdkit…annotation-properties.fields-descriptor.derived-from   ← wrong
jobs.cluster-butina…annotation-properties.derived-from                              ← the other 8
```

An indentation slip — 16 spaces where 14 were meant. The other eight occurrences
in this file are correct, which makes the intent unambiguous.

It survived because `annotation-properties` was declared
`additionalProperties: true`, so the block was free-form and *any* key validated.
2.7.0 models it properly and the slip surfaced. This is exactly the class of hole
[`docs/schema-coverage.md`](https://github.com/InformaticsMatters/squonk2-jobs/blob/main/docs/schema-coverage.md)
describes, and closing it found a genuine latent defect first time out.

## Why the version bump

Not purely cosmetic. This output has been shipping a `fields-descriptor` carrying
a stray key and **no `derived-from` annotation at all**. Fixing the placement
changes the annotation the Data Manager actually receives, so
`similarity-screen-rdkit` goes `1.0.1` → `1.0.2` per
[the versioning rules](https://github.com/InformaticsMatters/squonk2-jobs/blob/main/docs/versioning.md).

## Verification

Reproduced CI exactly — jote 0.13.0 resolving decoder 2.7.0:

| Manifest | Result |
| -------- | ------ |
| `manifest-im-virtual-screening.yaml` | 32/32 |
| `manifest-moldb.yaml` | 12/12 |
| `manifest-fragnet-search.yaml` | 3/3 |
| `manifest-im-mordred.yaml` | 2/2 |
| `manifest-dmpk.yaml` | 1/1 |
| `manifest-silicos-it.yaml` | 0/0 |

Before the fix, `manifest-im-virtual-screening.yaml` failed; all six now pass.

I also validated **every** Job Definition across all ten Job repositories against
the 2.7.0 schema: this was the **only** violation in the ecosystem, so no other
repository needs changing.

## Related

A companion PR in `squonk2-jobs` pins the decoder in CI. The umbrella workflow
pins `JOTE_VERSION` but jote declares `im-data-manager-job-decoder>=2.6.1` with no
upper bound — the schemas live in the decoder, so they float, and a decoder
release lands as a failure on whatever unrelated PR comes next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)