### PR TITLE
fix: pin silicos-it Jobs to the only tag that exists

### DIFF
--- a/data-manager/silicos-it.yaml
+++ b/data-manager/silicos-it.yaml
@@ -11,7 +11,7 @@ jobs:
     name: 3D shape alignment with shape-it
     description: >-
       Perform a shape alignment of a set of 3D molecules to a reference 3D molecule using Silicos-it's shape-it tool.
-    version: '1.0.0'
+    version: '1.0.1'
     category: virtual screening
     keywords:
     - alignment
@@ -21,8 +21,12 @@ jobs:
     - filter
     - 3d
     image:
+      # A third-party image we do not control and cannot republish, so the
+      # usual "pin an immutable tag" rule cannot be applied here - 'latest'
+      # is the only tag 3dechem/silicos-it has ever published (2017-08-15).
+      # See docs/versioning.md in the squonk2-jobs umbrella repository.
       name: 3dechem/silicos-it
-      tag: 'stable'
+      tag: 'latest'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -128,7 +132,7 @@ jobs:
     name: Pharmacophore alignment with align-it
     description: >-
       Perform an alignment of pre-generated pharmacophores to a reference 3D molecule using Silicos-it's align-it tool.
-    version: '1.0.0'
+    version: '1.0.1'
     category: virtual screening
     keywords:
     - alignment
@@ -138,8 +142,10 @@ jobs:
     - filter
     - 3d
     image:
+      # See the note on shape-it-search above: 'latest' is the only tag this
+      # third-party image publishes.
       name: 3dechem/silicos-it
-      tag: 'stable'
+      tag: 'latest'
       project-directory: /data
       working-directory: /data
       fix-permissions: true


### PR DESCRIPTION
## The bug

Both Jobs in the `silicos-it` collection pinned `3dechem/silicos-it:stable`.
**That tag has never existed.** Queried against the registry just now:

```
3dechem/silicos-it:latest -> HTTP 200
3dechem/silicos-it:stable -> HTTP 404
```

The repository has published exactly one tag — `latest`, last pushed
**2017-08-15**. So neither `shape-it-search` nor `align-it-search` could ever
pull its image.

`manifest-silicos-it.yaml` is a **deployed manifest** (it is listed on the Data
Manager wiki's Day 1 Jobs page), so this is live breakage rather than a latent
problem.

## The fix

Pin `latest`, and bump both Jobs `1.0.0` → `1.0.1`.

## On using a dynamic tag here

`latest` is a dynamic tag, which production Job Definitions should not normally
use. This image is the documented exception: it is third-party, we cannot
republish it, and it is the only tag on offer.

Pinning a **digest** would be the usual way to get immutability without the
upstream's cooperation — but it is not currently representable: the Job
Definition schema caps `image.tag` at **24 characters**, and a `sha256:` digest
needs 71. Worth knowing, because "pin a digest" is one of the candidate answers
to the third-party image question in
[squonk2-jobs#43](https://github.com/InformaticsMatters/squonk2-jobs/issues/43),
and it would need a schema change first.

In practice the image has not moved in nine years, so the dynamic-tag risk here
is close to theoretical.

## Why it went unnoticed

**Both Jobs have no tests.** jote reports `found=0` for this manifest, so nothing
has ever attempted a pull — a dry-run validates the definition and a full run
finds nothing to execute. Adding even a minimal test for each would have caught
this. Not done here, to keep the fix to the breakage.

## Verification

jote 0.14.0 with decoder 2.7.0, all six manifests:

| Manifest | Result |
| -------- | ------ |
| `manifest-im-virtual-screening.yaml` | 32/32 |
| `manifest-moldb.yaml` | 12/12 |
| `manifest-fragnet-search.yaml` | 3/3 |
| `manifest-im-mordred.yaml` | 2/2 |
| `manifest-dmpk.yaml` | 1/1 |
| `manifest-silicos-it.yaml` | 0/0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)