### PR TITLE
fix: move moldb-count-rows options under variables, and correct them

### DIFF
--- a/data-manager/moldb.yaml
+++ b/data-manager/moldb.yaml
@@ -73,7 +73,7 @@ jobs:
     name: MolDB count rows
     description: >-
       Verify there are the expected number of rows in a database table
-    version: '1.0.0'
+    version: '1.0.1'
     # no category as this is only used as part of testing
     keywords:
     - moldb
@@ -110,20 +110,28 @@ jobs:
       {% if count is defined %}--expected-rows {{ count }}{% endif %}
       {% if min_rows is defined %}--min-rows {{ min_rows }}{% endif %}
       {% if max_rows is defined %}--max-rows {{ max_rows }}{% endif %}
-    options:
-      type: object
-      required:
-      - table
-      - count
-      - min_rows
-      - max_rows
-      properties:
-        table:
-          title: Table name
-          pattern: "^[A-Za-z0-9_\\.\\-]+$"
-        count:
-          title: Expected row count
-          type: integer
+    variables:
+      options:
+        type: object
+        # Only 'table' is always needed. The command guards the other three
+        # with '{% if ... is defined %}': a caller supplies either 'count'
+        # (exact) or 'min_rows'/'max_rows' (a range), not all of them.
+        required:
+        - table
+        properties:
+          table:
+            title: Table name
+            type: string
+            pattern: "^[A-Za-z0-9_\\.\\-]+$"
+          count:
+            title: Expected row count
+            type: integer
+          min_rows:
+            title: Minimum row count
+            type: integer
+          max_rows:
+            title: Maximum row count
+            type: integer
     tests:
       supply:
         run-groups:


### PR DESCRIPTION
`moldb-count-rows` had its `options:` block directly on the job rather than under
`variables:`. The schema's `job` object does not set
`additionalProperties: false`, so the stray key validated silently and the
options were **ignored** — this is hole 2 in
[`docs/schema-coverage.md`](https://github.com/InformaticsMatters/squonk2-jobs/blob/main/docs/schema-coverage.md).

## This is not just a move

Because nothing ever validated the block, it had drifted into a state that could
not have worked. Moving it unchanged produces a schema error *and* breaks all
three tests:

```
jobs.moldb-count-rows.variables.options.properties.table: 'type' is a required property

test supply       would be missing required ['min_rows', 'max_rows']
test enumeration  would be missing required ['min_rows', 'max_rows']
test conformer    would be missing required ['count']
```

Three separate defects:

- **`required` listed all four** of `table`, `count`, `min_rows`, `max_rows`. But
  the command guards the last three with `{% if ... is defined %}`, and no caller
  supplies all four — `count` (an exact count) and `min_rows`/`max_rows` (a
  range) are alternatives. Every test would have failed.
- **`table` had no `type`**, which `job-option-property` requires.
- **`min_rows` and `max_rows` were required but never defined.**

So the block is relocated *and* corrected: only `table` is required, `table`
gains `type: string`, and `min_rows`/`max_rows` are properly declared.

## Why the version bump

The Job could not previously be run from the Data Manager at all — with no
options visible there was no way to supply the table name its command needs. It
has only ever worked under `jote`, which passes options directly. Making the
options real is a behaviour change, so `1.0.0` → `1.0.1`.

## Sequencing

This unblocks closing hole 2 in the decoder (adding `additionalProperties: false`
to the `job` object). That closure would turn this silent no-op into a hard
failure, so the Job had to be fixed first — the lesson from decoder 2.7.0, which
closed a different hole and failed two unrelated merges.

## Verification

jote 0.14.0 with decoder 2.7.0:

| Manifest | Result |
| -------- | ------ |
| `manifest-im-virtual-screening.yaml` | 32/32 |
| `manifest-moldb.yaml` | 12/12 |
| `manifest-fragnet-search.yaml` | 3/3 |
| `manifest-im-mordred.yaml` | 2/2 |
| `manifest-dmpk.yaml` | 1/1 |
| `manifest-silicos-it.yaml` | 0/0 |

Each of the three tests' supplied options was also validated directly against the
corrected options schema — all three pass.

Refs InformaticsMatters/squonk2-jobs#8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)