### PR TITLE
chore: drop the unused repository-url and repository-tag keys

### DIFF
--- a/data-manager/moldb.yaml
+++ b/data-manager/moldb.yaml
@@ -3,8 +3,6 @@ kind: DataManagerJobDefinition
 kind-version: '2021.1'
 name: MolDB tools
 collection: moldb
-repository-url: https://github.com/InformaticsMatters/virtual-screening/moldb.yaml
-repository-tag: '1.0.0'
 
 test-groups:
 - name: moldb


### PR DESCRIPTION
`moldb.yaml` was the only Job Definition in the ecosystem carrying these two
top-level keys.

## Nothing reads them

Zero hits across the job decoder, the job operator, the job utilities and the
job tester. They are not in the schema, not in the documentation, and not in any
other definition.

## Both values were wrong from the day they were written

| Key | Value | Reality |
| --- | ----- | ------- |
| `repository-url` | `.../virtual-screening/moldb.yaml` | **404** — the real path is `/blob/main/data-manager/moldb.yaml` |
| `repository-tag` | `'1.0.0'` | Tag `1.0.0` is from **2021-06-02**; `moldb.yaml` was created **2022-10-05**, so the file does not exist at the tag it names |

They arrived with the file in `d16c539` ("more complete moldb workflows",
2022-10-05) and were never touched again. This is boilerplate that was never
correct and never consumed — not a convention that lost its tooling.

## On the intent

The idea behind them — recording the fixed point a definition came from — is
sound, and was reaching for what
[squonk2-jobs#43](https://github.com/InformaticsMatters/squonk2-jobs/issues/43)
later concluded. But it is met properly by loading a manifest from a **repository
tag**; a self-referential field inside the definition can only drift from the
truth, as both of these did within months.

## Impact

None. No Job behaviour changes and no Job version is affected — these are
file-level keys that nothing read.

## Why now

This clears the live example behind **hole 1** in
[`docs/schema-coverage.md`](https://github.com/InformaticsMatters/squonk2-jobs/blob/main/docs/schema-coverage.md)
— the last of three blockers preventing the schema's remaining objects from
setting `additionalProperties: false`.

With this merged, simulating the closure of **all three** remaining holes (root
object, `job`, `test-checks-output`) against every Job Definition in the
ecosystem produces **zero errors**. A companion decoder PR follows.

## Verification

jote 0.14.0 with decoder 2.7.0 — `manifest-moldb.yaml` passes **12/12**.

Refs InformaticsMatters/squonk2-jobs#8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)