### PR TITLE
feat: reset all Jobs to a single pinned 2.0.0 release

### DIFF
--- a/.github/workflows/publish-tag.yaml
+++ b/.github/workflows/publish-tag.yaml
@@ -1,0 +1,51 @@
+---
+name: publish-tag
+
+# Actions that publish a set of immutable, statically-tagged images.
+#
+# Run this manually when cutting a release. The tag you give is the tag every
+# image is published with, and it must be one that has never been published
+# before - the Data Manager treats any tag other than 'latest' or 'stable' as
+# static and caches it per Kubernetes node, so a reused tag leaves some nodes
+# running the old content. See docs/versioning.md in the squonk2-jobs
+# umbrella repository.
+#
+# Note that 'informaticsmatters/vs-rdkit-base' is not built here - it is built
+# and pushed by hand, and five of the images below are FROM it. Publish the
+# matching base image before running this workflow.
+
+# -----------------
+# Control variables (GitHub Secrets)
+# -----------------
+#
+# At the GitHub 'organisation' or 'project' level you must have the following
+# GitHub 'Repository Secrets' defined (i.e. via 'Settings -> Secrets'): -
+#
+# DOCKERHUB_USERNAME
+# DOCKERHUB_TOKEN
+#
+# -----------
+# Environment (GitHub Environments)
+# -----------
+#
+# Environment         (n/a)
+
+on:
+  workflow_dispatch:
+    inputs:
+      image-tag:
+        description: The immutable image tag to build and publish (e.g. 2.0.0)
+        type: string
+        required: true
+
+jobs:
+  call-test:
+    uses: ./.github/workflows/test.yaml
+
+  call-build-with-push:
+    needs: call-test
+    uses: ./.github/workflows/build-all-with-push-option.yaml
+    secrets: inherit
+    with:
+      image-tag: ${{ inputs.image-tag }}
+      image-push: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,3 +27,4 @@ jobs:
         jote --manifest manifest-silicos-it.yaml --dry-run --allow-no-tests
         jote --manifest manifest-dmpk.yaml --dry-run
         jote --manifest manifest-im-mordred.yaml --dry-run
+        jote --manifest manifest-moldb.yaml --dry-run

--- a/Dockerfile-fns
+++ b/Dockerfile-fns
@@ -1,4 +1,4 @@
-FROM informaticsmatters/vs-rdkit-base:latest
+FROM informaticsmatters/vs-rdkit-base:2.0.0
 
 # Note:     When run by the Data Manager the uid and gid
 #           will be set according to the Project we're running against.

--- a/Dockerfile-moldb
+++ b/Dockerfile-moldb
@@ -1,4 +1,4 @@
-FROM informaticsmatters/vs-rdkit-base:latest
+FROM informaticsmatters/vs-rdkit-base:2.0.0
 
 # Note:     When run by the Data Manager the uid and gid
 #           will be set according to the Project we're running against.

--- a/Dockerfile-mordred
+++ b/Dockerfile-mordred
@@ -1,4 +1,4 @@
-FROM informaticsmatters/vs-rdkit-base:latest
+FROM informaticsmatters/vs-rdkit-base:2.0.0
 
 # Note:     When run by the Data Manager the uid and gid
 #           will be set according to the Project we're running against.

--- a/Dockerfile-oddt
+++ b/Dockerfile-oddt
@@ -1,4 +1,4 @@
-FROM informaticsmatters/vs-rdkit-base:latest
+FROM informaticsmatters/vs-rdkit-base:2.0.0
 
 # Note:     When run by the Data Manager the uid and gid
 #           will be set according to the Project we're running against.

--- a/Dockerfile-prep
+++ b/Dockerfile-prep
@@ -1,4 +1,4 @@
-FROM informaticsmatters/vs-rdkit-base:latest
+FROM informaticsmatters/vs-rdkit-base:2.0.0
 
 # Note:     When run by the Data Manager the uid and gid
 #           will be set according to the Project we're running against.

--- a/README.md
+++ b/README.md
@@ -19,12 +19,26 @@ These tools are available under the [Apache2.0 license](LICENSE).
 ## Building
 The image builds are accomplished using GitHib workflows in this repository.
 
-The `rdkit-base` image on which a number of the other images depend on is
+The `vs-rdkit-base` image on which a number of the other images depend on is
 built manually and pushed to docker hub when the RDKit release needs to be updated.
-At the moment we push the image `informaticsmatters/rdkit-base:latest`, and this is
-controlled by the dockerfile `Dockerfile-rdkit-base`.
+It is controlled by the dockerfile `Dockerfile-rdkit-base`, and is pushed with
+the release tag that the dependent images will use: -
+
+    $ IMAGE_TAG=2.0.0 docker-compose -f docker-compose-manual.yaml build
+    $ IMAGE_TAG=2.0.0 docker-compose -f docker-compose-manual.yaml push
+
+Publish it *before* running the release workflow below - `Dockerfile-fns`,
+`-moldb`, `-mordred`, `-oddt` and `-prep` are all `FROM` it and will fail to
+build without it.
 
 The other images are built automatically by the GitHub workflows, where: -
 
+- The `publish-tag` workflow, run manually, results in a series of images
+  carrying the tag you give it (e.g. `:2.0.0`). This is how releases are made:
+  the Job Definitions pin these static tags, so **a tag must never be reused**
 - Every change to the `main` branch results in a series of `:stable` images
 - Every change to the `staging` branch results in a series of `:latest` images
+
+`:stable` and `:latest` are dynamic tags, intended for development only. See
+[versioning](https://github.com/InformaticsMatters/squonk2-jobs/blob/main/docs/versioning.md)
+in the `squonk2-jobs` umbrella repository.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -11,7 +11,7 @@ yourself for some reason this is how...
 
 To build the container images run this:
 
-    $ IMAGE_TAG=1.0.0 docker-compose build 
+    $ IMAGE_TAG=2.0.0 docker-compose build 
 
 Or, to build using the `latest` tag: -
 

--- a/data-manager/dmpk.yaml
+++ b/data-manager/dmpk.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Estimation of absorption
     description: >-
       Estimation of absorption from t1/2 and Tmax after po administration (one-compartment)
-    version: '1.0.0'
+    version: '2.0.0'
     category: dmpk
     keywords:
     - dmpk
@@ -18,7 +18,7 @@ jobs:
     - kel
     image:
       name: informaticsmatters/vs-dmpk
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true

--- a/data-manager/fragnet-search.yaml
+++ b/data-manager/fragnet-search.yaml
@@ -20,14 +20,14 @@ jobs:
     name: Fragment network expansion
     description: >-
       Expand a set of molecules using the fragment network
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - fragment-network
     - candidate-selection
     image:
       name: informaticsmatters/vs-fragnet-search
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -137,7 +137,7 @@ jobs:
     name: Fragment network find synthons
     description: >-
       Find the "synthons" of a molecule
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - fragment-network
@@ -145,7 +145,7 @@ jobs:
     - synthons
     image:
       name: informaticsmatters/vs-fragnet-search
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -222,14 +222,14 @@ jobs:
     name: Fragment network expansion
     description: >-
       Expand a set of molecules using the fragment network
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - fragment-network
     - candidate-selection
     image:
       name: informaticsmatters/vs-fragnet-search
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true

--- a/data-manager/im-virtual-screening.yaml
+++ b/data-manager/im-virtual-screening.yaml
@@ -60,13 +60,13 @@ jobs:
     name: Test failures
     description: >-
       Simple job that allows how errors are handled to be tested
-    version: '1.0.0'
+    version: '2.0.0'
     category: miscellaneous
     keywords:
     - test
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -136,14 +136,14 @@ jobs:
     description: >-
       Convert molecular formats using OpenBabel. Can be used to prepare a protein for docking.
       See the docs for more info of all the options.
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - protein preparation
     - openbabel
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -197,7 +197,7 @@ jobs:
       Prepare a protein for docking by using pdb2pqr. This can replace missing heavy atoms
       and protonate the protein at a specific pH taking into account the local environment
       of titratable groups, such as the hydrogen bonding network.
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - protein preparation
@@ -206,7 +206,7 @@ jobs:
     - 3d
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -286,7 +286,7 @@ jobs:
     name: rDock prepare
     description: >-
       Prepare rDock configuration file (.prm file) and the cavity definition (.as file).
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - protein preparation
@@ -294,7 +294,7 @@ jobs:
     - 3d
     image:
       name: informaticsmatters/vs-rdock
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -349,7 +349,7 @@ jobs:
     name: USR shape similarity
     description: >-
       Filters molecules using 3D shape similarity and the USR, Electroshape or USRCAT algorithms
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - oddt
@@ -362,7 +362,7 @@ jobs:
     - 3d
     image:
       name: informaticsmatters/vs-oddt
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -456,7 +456,7 @@ jobs:
     description: >-
       Sorts records in a SD-file, optionally keeping top n.
       Do not use for very large files.
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - rdock
@@ -466,7 +466,7 @@ jobs:
     doc-url: im-virtual-screening/rdock-filter-sdf.md
     image:
       name: informaticsmatters/vs-rdock
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -560,7 +560,7 @@ jobs:
     name: Filter the contents of a SDF
     description: >-
       Filters records in a SD-file, sorted within consecutive groups, sorting the results and optionally keeping the top n.
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - rdock
@@ -570,7 +570,7 @@ jobs:
     doc-url: im-virtual-screening/rdock-filter-sdf.md
     image:
       name: informaticsmatters/vs-rdock
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -672,14 +672,14 @@ jobs:
     name: Convert SDF to JSON format
     description: >-
       Converts a SD file to Squonk JSON format
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - convert
     - format
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -725,7 +725,7 @@ jobs:
     name: Enumerate microstates, tautomers and undefined chiral centres
     description: >-
       Enumerate microstates, tautomers and undefined chiral centres.
-    version: '1.0.1'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - rdkit
@@ -735,7 +735,7 @@ jobs:
     - 3d
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -940,7 +940,7 @@ jobs:
     name: Run rDock docking
     description: >-
       Run rDock docking.
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - rdock
@@ -949,7 +949,7 @@ jobs:
     - 3d
     image:
       name: informaticsmatters/vs-nextflow
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: nextflow
@@ -1068,7 +1068,7 @@ jobs:
     name: Run smina docking
     description: >-
       Run smina docking.
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - smina
@@ -1077,7 +1077,7 @@ jobs:
     - 3d
     image:
       name: informaticsmatters/vs-nextflow
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: nextflow
@@ -1191,7 +1191,7 @@ jobs:
     name: ODDT rescoring and interactions
     description: >-
       Generate rescoring functions and interactions using ODDT.
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - oddt
@@ -1200,7 +1200,7 @@ jobs:
     - 3d
     image:
       name: informaticsmatters/vs-nextflow
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: nextflow
@@ -1259,7 +1259,7 @@ jobs:
     name: Align molecules to fragments using PLANTS
     description: >-
       Job that performs flexible alignment of candidate molecules to fragments using PLANTS
-    version: '1.0.0'
+    version: '2.0.0'
     category: ligand based virtual screening
     keywords:
     - plants
@@ -1268,7 +1268,7 @@ jobs:
     doc-url: im-virtual-screening/ph4-align-to-fragments.md
     image:
       name: informaticsmatters/vs-plants
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -1406,7 +1406,7 @@ jobs:
     name: Align SMILES to fragments using PLANTS
     description: >-
       Job that performs flexible alignment of candidate molecules to fragments using PLANTS
-    version: '1.0.0'
+    version: '2.0.0'
     category: ligand based virtual screening
     keywords:
     - plants
@@ -1415,7 +1415,7 @@ jobs:
     doc-url: im-virtual-screening/ph4-align-to-fragments.md
     image:
       name: informaticsmatters/vs-plants
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -1524,7 +1524,7 @@ jobs:
     description: >-
       Workflow that does parallel flexible alignment of candidate molecules to fragments using PLANTS, followed by
       scoring with open3Dalign.
-    version: '1.0.0'
+    version: '2.0.0'
     category: ligand based virtual screening
     keywords:
     - plants
@@ -1534,7 +1534,7 @@ jobs:
     doc-url: im-virtual-screening/ph4-align-to-fragments.md
     image:
       name: informaticsmatters/vs-nextflow
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: nextflow
@@ -1734,7 +1734,7 @@ jobs:
     name: Enumerate microstates, tautomers and undefined chiral centres
     description: >-
       Enumerate microstates, tautomers and undefined chiral centres (parallel execution)
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - rdkit
@@ -1745,7 +1745,7 @@ jobs:
     - nextflow
     image:
       name: informaticsmatters/vs-nextflow
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: nextflow

--- a/data-manager/moldb.yaml
+++ b/data-manager/moldb.yaml
@@ -20,14 +20,14 @@ jobs:
     name: Create MolDB database tables
     description: >-
       Create MolDB database tables
-    version: '1.0.0'
+    version: '2.0.0'
     # no category as this is only used as part of testing
     keywords:
     - moldb
     - database
     image:
       name: informaticsmatters/vs-moldb
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: simple
@@ -71,14 +71,14 @@ jobs:
     name: MolDB count rows
     description: >-
       Verify there are the expected number of rows in a database table
-    version: '1.0.1'
+    version: '2.0.0'
     # no category as this is only used as part of testing
     keywords:
     - moldb
     - database
     image:
       name: informaticsmatters/vs-moldb
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: simple
@@ -179,7 +179,7 @@ jobs:
     name: MolDB load library
     description: >-
       Load compound library into MolDB
-    version: '1.0.0'
+    version: '2.0.0'
     category: ligand preparation
     keywords:
     - moldb
@@ -187,7 +187,7 @@ jobs:
     - library
     image:
       name: informaticsmatters/vs-nextflow
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: nextflow
@@ -305,7 +305,7 @@ jobs:
     name: MolDB molecular properties
     description: >-
       Calculate molecular properties and load into MolDB
-    version: '1.0.0'
+    version: '2.0.0'
     category: ligand preparation
     keywords:
     - moldb
@@ -313,7 +313,7 @@ jobs:
     - molecular properties
     image:
       name: informaticsmatters/vs-nextflow
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: nextflow
@@ -386,7 +386,7 @@ jobs:
     name: MolDB enumerate forms
     description: >-
       Enumerate tautomers, microstates and stereoisomers
-    version: '1.0.0'
+    version: '2.0.0'
     category: ligand preparation
     keywords:
     - moldb
@@ -397,7 +397,7 @@ jobs:
     - stereoisomers
     image:
       name: informaticsmatters/vs-nextflow
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: nextflow
@@ -487,7 +487,7 @@ jobs:
     name: MolDB generate conformers
     description: >-
       Generate multiple low energy conformers
-    version: '1.0.0'
+    version: '2.0.0'
     category: ligand preparation
     keywords:
     - moldb
@@ -495,7 +495,7 @@ jobs:
     - conformers
     image:
       name: informaticsmatters/vs-nextflow
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: nextflow
@@ -585,14 +585,14 @@ jobs:
     name: MolDB extract molecules
     description: >-
       Extract base molecules
-    version: '1.0.0'
+    version: '2.0.0'
     category: ligand preparation
     keywords:
     - moldb
     - database
     image:
       name: informaticsmatters/vs-moldb
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: simple
@@ -686,7 +686,7 @@ jobs:
     name: MolDB extract enumerated forms
     description: >-
       Extract enumerated tautomers, microstates and stereoisomers
-    version: '1.0.0'
+    version: '2.0.0'
     category: ligand preparation
     keywords:
     - moldb
@@ -697,7 +697,7 @@ jobs:
     - stereoisomers
     image:
       name: informaticsmatters/vs-moldb
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: simple
@@ -817,7 +817,7 @@ jobs:
     name: MolDB extract low energy conformers
     description: >-
       Extract extract low energy conformers
-    version: '1.0.0'
+    version: '2.0.0'
     category: ligand preparation
     keywords:
     - moldb
@@ -826,7 +826,7 @@ jobs:
     - 3d
     image:
       name: informaticsmatters/vs-moldb
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: simple
@@ -946,14 +946,14 @@ jobs:
     name: MolDB analyse database contents
     description: >-
       Analyse the database contents to establish what actions are needed
-    version: '1.0.0'
+    version: '2.0.0'
     category: ligand preparation
     keywords:
     - moldb
     - database
     image:
       name: informaticsmatters/vs-moldb
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: simple

--- a/data-manager/mordred.yaml
+++ b/data-manager/mordred.yaml
@@ -9,7 +9,7 @@ jobs:
     name: 2D/3D Mordred descriptor generation
     description: >-
       Generate Mordred descriptors for molecules
-    version: '1.0.0'
+    version: '2.0.0'
     category: comp chem
     keywords:
     - rdkit
@@ -17,7 +17,7 @@ jobs:
     - descriptors
     image:
       name: informaticsmatters/mordred
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true

--- a/data-manager/rdkit.yaml
+++ b/data-manager/rdkit.yaml
@@ -10,7 +10,7 @@ jobs:
     description: >-
       Select a diverse subset of molecules using the RDKit MaxMin Picker.
       Morgan 2 fingerprints and Tanimoto distance is used.
-    version: '1.0.0'
+    version: '2.0.0'
     category: comp chem
     keywords:
     - rdkit
@@ -20,7 +20,7 @@ jobs:
     - filter
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -114,7 +114,7 @@ jobs:
   generate-low-energy-conformers:
     name: Generate 3D conformers
     description: Generate a low energy 3D conformers of molecules
-    version: '1.0.1'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - rdkit
@@ -123,7 +123,7 @@ jobs:
     - 3d
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -260,7 +260,7 @@ jobs:
     name: Generate 3D conformers of a molecule
     description: >-
       Generate a low energy 3D conformers. The input is a molfile or SMILES. The output is a SD file.
-    version: '1.0.0'
+    version: '2.0.0'
     category: comp chem
     keywords:
     - rdkit
@@ -268,7 +268,7 @@ jobs:
     - 3d
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -358,7 +358,7 @@ jobs:
     name: 3D alignment using Open3DAlign
     description: >-
       Aligns conformers to a target molecule, with optional filtering
-    version: '1.0.0'
+    version: '2.0.0'
     category: comp chem
     keywords:
     - open3Dalign
@@ -369,7 +369,7 @@ jobs:
     - 3d
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -469,14 +469,14 @@ jobs:
     name: Molecular property calculations
     description: >-
       Calculates molecular properties using RDKit
-    version: '1.0.1'
+    version: '2.0.0'
     category: molecular properties
     keywords:
     - rdkit
     - properties
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -685,14 +685,14 @@ jobs:
     name: Deduplicate molecules
     description: >-
       Deduplicate molecules using RDKit
-    version: '1.0.2'
+    version: '2.0.0'
     category: molecular properties
     keywords:
     - rdkit
     - properties
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -828,7 +828,7 @@ jobs:
     name: Synthetic accessibility score
     description: >-
       Calculates a synthetic accessibility score based on the approach of Ertl and Schuffenhauer
-    version: '1.0.1'
+    version: '2.0.0'
     category: molecular properties
     keywords:
     - rdkit
@@ -836,7 +836,7 @@ jobs:
     - sa_score
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -944,7 +944,7 @@ jobs:
       Filters molecules by molecular similarity using RDKit.
       A number of descriptors and metrics are available.
       Query molecule(s) are specified from a project file or as SMILES.
-    version: '1.0.2'
+    version: '2.0.0'
     category: comp chem
     keywords:
     - rdkit
@@ -955,7 +955,7 @@ jobs:
     - filter
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -1161,7 +1161,7 @@ jobs:
     name: Energy minimize molecules
     description: >-
       Energy minimize molecules using RDKit and the MMFF94 force field
-    version: '1.0.0'
+    version: '2.0.0'
     category: comp chem
     keywords:
     - rdkit
@@ -1172,7 +1172,7 @@ jobs:
     - 3d
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -1247,7 +1247,7 @@ jobs:
     name: Align molecules
     description: >-
       Align molecules to a template molecule using MCS to determine matching atoms
-    version: '1.0.0'
+    version: '2.0.0'
     category: comp chem
     keywords:
     - rdkit
@@ -1255,7 +1255,7 @@ jobs:
     - alignment
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -1380,7 +1380,7 @@ jobs:
     name: Butina Clustering
     description: >-
       Cluster molecules with Butina and RDKit fingerprints
-    version: '1.0.1'
+    version: '2.0.0'
     category: comp chem
     keywords:
     - rdkit
@@ -1389,7 +1389,7 @@ jobs:
     - fingerprint
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -1616,14 +1616,14 @@ jobs:
     name: Filter SD-file based on its properties
     description: >-
       Filter the records of a SD-file based or field property values
-    version: '1.0.0'
+    version: '2.0.0'
     category: miscellaneous
     keywords:
     - rdkit
     - filter
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -1705,7 +1705,7 @@ jobs:
     name: Reaction enumeration using RDKit
     description: >-
       Enumerate products using RDKit. Inputs are a reaction SMARTS string and SMILES files with reactants.
-    version: '1.0.0'
+    version: '2.0.0'
     category: molecular libraries
     keywords:
     - rdkit
@@ -1714,7 +1714,7 @@ jobs:
     - library
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true
@@ -1829,7 +1829,7 @@ jobs:
   generate-low-energy-conformers-multi:
     name: Generate 3D conformers
     description: Generate a low energy 3D conformers of molecules (parallel execution)
-    version: '1.0.0'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - rdkit
@@ -1839,7 +1839,7 @@ jobs:
     - 3d
     image:
       name: informaticsmatters/vs-nextflow
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       type: nextflow

--- a/data-manager/silicos-it.yaml
+++ b/data-manager/silicos-it.yaml
@@ -11,7 +11,7 @@ jobs:
     name: 3D shape alignment with shape-it
     description: >-
       Perform a shape alignment of a set of 3D molecules to a reference 3D molecule using Silicos-it's shape-it tool.
-    version: '1.0.1'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - alignment
@@ -132,7 +132,7 @@ jobs:
     name: Pharmacophore alignment with align-it
     description: >-
       Perform an alignment of pre-generated pharmacophores to a reference 3D molecule using Silicos-it's align-it tool.
-    version: '1.0.1'
+    version: '2.0.0'
     category: virtual screening
     keywords:
     - alignment

--- a/data-manager/xchem.yaml
+++ b/data-manager/xchem.yaml
@@ -10,7 +10,7 @@ jobs:
     description: >-
       Generate shape overlay scores using SuCOS.
       The molecules need to be already aligned.
-    version: '1.0.0'
+    version: '2.0.0'
     category: comp chem
     keywords:
     - rdkit
@@ -19,7 +19,7 @@ jobs:
     - sucos
     image:
       name: informaticsmatters/vs-prep
-      tag: 'stable'
+      tag: '2.0.0'
       project-directory: /data
       working-directory: /data
       fix-permissions: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,8 @@ version: '3.0'
 
 # Build and push with: -
 #
-# IMAGE_TAG=1.0.0 docker-compose build
-# IMAGE_TAG=1.0.0 docker-compose push
+# IMAGE_TAG=2.0.0 docker-compose build
+# IMAGE_TAG=2.0.0 docker-compose push
 #
 # ----
 # NOTE: This file is for copnvenience, it does not feature in the CI build process.

--- a/moldb/k8s-create-tables.yaml
+++ b/moldb/k8s-create-tables.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: moldb-create-tables
-    image: informaticsmatters/vs-moldb:stable
+    image: informaticsmatters/vs-moldb:2.0.0
     command: [ 'python', '-m', 'moldb.create_db' ]
     env:
     - name: POSTGRES_SERVER

--- a/nf-processes/file/concatenate_files.nf
+++ b/nf-processes/file/concatenate_files.nf
@@ -6,7 +6,7 @@ params.optional = false
 
 process concatenate_files {
 
-    container 'informaticsmatters/vs-prep:stable'
+    container 'informaticsmatters/vs-prep:2.0.0'
     if (params.publish_dir) { publishDir params.publish_dir, mode: params.publish_dir_mode }
 
     input:

--- a/nf-processes/file/split_sdf.nf
+++ b/nf-processes/file/split_sdf.nf
@@ -17,7 +17,7 @@ params.chunk_size = 1000
 
 process split_sdf {
 
-    container 'informaticsmatters/vs-rdock:stable'
+    container 'informaticsmatters/vs-rdock:2.0.0'
 
     input:
     path molecules

--- a/nf-processes/file/split_txt.nf
+++ b/nf-processes/file/split_txt.nf
@@ -21,7 +21,7 @@ params.chunk_size = 1000
 
 process split_txt {
 
-    container 'informaticsmatters/vs-prep:stable'
+    container 'informaticsmatters/vs-prep:2.0.0'
 
     input:
     file inputs

--- a/nf-processes/moldb/calc_molprops.nf
+++ b/nf-processes/moldb/calc_molprops.nf
@@ -5,7 +5,7 @@ params.interval = 10000
 
 process calc_molprops {
 
-    container 'informaticsmatters/vs-moldb:stable'
+    container 'informaticsmatters/vs-moldb:2.0.0'
     if (params.publish_dir) { publishDir params.publish_dir, mode: params.publish_dir_mode }
 
     input:

--- a/nf-processes/moldb/db_extract.nf
+++ b/nf-processes/moldb/db_extract.nf
@@ -3,7 +3,7 @@ params.outfile = 'outputs.smi'
 
 process extract_molprops {
 
-    container 'informaticsmatters/vs-moldb:stable'
+    container 'informaticsmatters/vs-moldb:2.0.0'
 
     output:
     file params.outfile

--- a/nf-processes/moldb/db_load.nf
+++ b/nf-processes/moldb/db_load.nf
@@ -5,7 +5,7 @@ params.library_name = 'no_name'
 
 process load_standardized {
 
-    container 'informaticsmatters/vs-moldb:stable'
+    container 'informaticsmatters/vs-moldb:2.0.0'
     maxForks 1
     errorStrategy { sleep(Math.pow(2, task.attempt) * 1000 as long); return 'retry' }
     maxRetries 3
@@ -20,7 +20,7 @@ process load_standardized {
 
 process load_molprops {
 
-    container 'informaticsmatters/vs-moldb:stable'
+    container 'informaticsmatters/vs-moldb:2.0.0'
     maxForks 1
     errorStrategy { sleep(Math.pow(2, task.attempt) * 1000 as long); return 'retry' }
     maxRetries 3
@@ -41,7 +41,7 @@ process load_molprops {
 
 process load_enum {
 
-    container 'informaticsmatters/vs-moldb:stable'
+    container 'informaticsmatters/vs-moldb:2.0.0'
     maxForks 1
     errorStrategy { sleep(Math.pow(2, task.attempt) * 1000 as long); return 'retry' }
     maxRetries 3
@@ -63,7 +63,7 @@ process load_enum {
 
 process load_conf {
 
-    container 'informaticsmatters/vs-moldb:stable'
+    container 'informaticsmatters/vs-moldb:2.0.0'
     maxForks 1
     errorStrategy { sleep(Math.pow(2, task.attempt) * 1000 as long); return 'retry' }
     maxRetries 3

--- a/nf-processes/moldb/enumerate.nf
+++ b/nf-processes/moldb/enumerate.nf
@@ -15,7 +15,7 @@ params.num_charges = null
 
 process enumerate {
 
-    container 'informaticsmatters/vs-moldb:stable'
+    container 'informaticsmatters/vs-moldb:2.0.0'
 
     input:
     file inputs

--- a/nf-processes/moldb/filter.nf
+++ b/nf-processes/moldb/filter.nf
@@ -6,7 +6,7 @@ params.count = 10000
 
 process extract_need_enum {
 
-    container 'informaticsmatters/vs-moldb:stable'
+    container 'informaticsmatters/vs-moldb:2.0.0'
     if (params.publish_dir) { publishDir params.publish_dir, mode: params.publish_dir_mode }
 
     input:
@@ -22,7 +22,7 @@ process extract_need_enum {
 
 process extract_need_conf {
 
-    container 'informaticsmatters/vs-moldb:stable'
+    container 'informaticsmatters/vs-moldb:2.0.0'
     if (params.publish_dir) { publishDir params.publish_dir, mode: params.publish_dir_mode }
 
     input:

--- a/nf-processes/moldb/gen_conformers.nf
+++ b/nf-processes/moldb/gen_conformers.nf
@@ -7,7 +7,7 @@ params.interval = 100
 
 process gen_conformers {
 
-    container 'informaticsmatters/vs-moldb:stable'
+    container 'informaticsmatters/vs-moldb:2.0.0'
     if (params.publish_dir) { publishDir params.publish_dir, mode: params.publish_dir_mode }
 
     input:

--- a/nf-processes/obabel/convert_format.nf
+++ b/nf-processes/obabel/convert_format.nf
@@ -8,7 +8,7 @@ params.output_file = 'reformatted'
 
 process convert_format {
 
-    container 'informaticsmatters/vs-prep:stable'
+    container 'informaticsmatters/vs-prep:2.0.0'
     scratch params.scratch
 
     input:

--- a/nf-processes/oddt/calc_interactions.nf
+++ b/nf-processes/oddt/calc_interactions.nf
@@ -18,7 +18,7 @@ See the Python oddt_interactions.py module for full details.
 */
 process calc_interactions {
 
-    container 'informaticsmatters/vs-oddt:stable'
+    container 'informaticsmatters/vs-oddt:2.0.0'
     errorStrategy 'retry'
     maxRetries 3
     scratch params.scratch

--- a/nf-processes/plants/pharmacophore.nf
+++ b/nf-processes/plants/pharmacophore.nf
@@ -10,7 +10,7 @@ params.delimiter = null
 
 process pharmacophore {
 
-    container 'informaticsmatters/vs-plants:stable'
+    container 'informaticsmatters/vs-plants:2.0.0'
 
     input:
     path inputs // .sdf or .smi

--- a/nf-processes/rdkit/assemble_conformers.nf
+++ b/nf-processes/rdkit/assemble_conformers.nf
@@ -6,7 +6,7 @@ params.interval = 10000
 
 process assemble {
 
-    container 'informaticsmatters/vs-prep:stable'
+    container 'informaticsmatters/vs-prep:2.0.0'
 
     input:
     path input // .smi

--- a/nf-processes/rdkit/enumerate.nf
+++ b/nf-processes/rdkit/enumerate.nf
@@ -34,7 +34,7 @@ params.num_charges = null
 
 process enumerate {
 
-    container 'informaticsmatters/vs-prep:stable'
+    container 'informaticsmatters/vs-prep:2.0.0'
 
     input:
     file inputs

--- a/nf-processes/rdkit/gen_confs.nf
+++ b/nf-processes/rdkit/gen_confs.nf
@@ -23,7 +23,7 @@ params.interval = 10
 
 process gen_conformers {
 
-    container 'informaticsmatters/vs-prep:stable'
+    container 'informaticsmatters/vs-prep:2.0.0'
 
     input:
     file inputs

--- a/nf-processes/rdkit/open3dalign.nf
+++ b/nf-processes/rdkit/open3dalign.nf
@@ -5,7 +5,7 @@ params.threshold = 0
 
 process open3dalign {
 
-    container 'informaticsmatters/vs-prep:stable'
+    container 'informaticsmatters/vs-prep:2.0.0'
 
     input:
     path inputs // .sdf

--- a/nf-processes/rdkit/prep_enum_conf_lists.nf
+++ b/nf-processes/rdkit/prep_enum_conf_lists.nf
@@ -5,7 +5,7 @@ params.interval = 10000
 
 process prep_lists {
 
-    container 'informaticsmatters/vs-prep:stable'
+    container 'informaticsmatters/vs-prep:2.0.0'
 
     input:
     path inputs // .smi

--- a/nf-processes/rdkit/standardize.nf
+++ b/nf-processes/rdkit/standardize.nf
@@ -8,7 +8,7 @@ params.skip_lines = 0
 
 process standardize {
 
-    container 'informaticsmatters/vs-moldb:stable'
+    container 'informaticsmatters/vs-moldb:2.0.0'
     if (params.publish_dir) { publishDir params.publish_dir, mode: params.publish_dir_mode }
 
     input:

--- a/nf-processes/rdock/filter.nf
+++ b/nf-processes/rdock/filter.nf
@@ -13,7 +13,7 @@ params.publish_dir_mode = 'copy'
 */
 process sd_sort_and_top {
 
-    container 'informaticsmatters/vs-rdock:stable'
+    container 'informaticsmatters/vs-rdock:2.0.0'
     if (params.publish_dir) { publishDir params.publish_dir, mode: params.publish_dir_mode }
 
     input:
@@ -33,7 +33,7 @@ and sort those best results.
 */
 process sd_best_sorted {
 
-    container 'informaticsmatters/vs-rdock:stable'
+    container 'informaticsmatters/vs-rdock:2.0.0'
     if (params.publish_dir) { publishDir params.publish_dir, mode: params.publish_dir_mode }
 
     input:
@@ -55,7 +55,7 @@ and sort those best results and keep the top n (params.top)
 */
 process sd_best_sorted_top {
 
-    container 'informaticsmatters/vs-rdock:stable'
+    container 'informaticsmatters/vs-rdock:2.0.0'
     if (params.publish_dir) { publishDir params.publish_dir, mode: params.publish_dir_mode }
 
     input:

--- a/nf-processes/rdock/rdock_docking.nf
+++ b/nf-processes/rdock/rdock_docking.nf
@@ -10,7 +10,7 @@ params.mode = 'dock' // or minimise, score etc. Look in /rDock_2013.1_src/data/s
 
 process rdock_docking {
 
-    container 'informaticsmatters/vs-rdock:stable'
+    container 'informaticsmatters/vs-rdock:2.0.0'
     //errorStrategy params.errorStrategy
     //maxRetries params.maxRetries
     errorStrategy { sleep(Math.pow(2, task.attempt) * 500 as long); return 'retry' }

--- a/nf-processes/smina/smina_docking.nf
+++ b/nf-processes/smina/smina_docking.nf
@@ -8,7 +8,7 @@ params.cpu = 1
 
 process smina_docking {
 
-    container 'informaticsmatters/vs-smina:stable'
+    container 'informaticsmatters/vs-smina:2.0.0'
     errorStrategy 'retry'
     maxRetries params.retries
     scratch params.scratch

--- a/nf-processes/xchem/sucos.nf
+++ b/nf-processes/xchem/sucos.nf
@@ -5,7 +5,7 @@ params.tanimoto = false
 
 process sucos {
 
-    container 'informaticsmatters/vs-prep:stable'
+    container 'informaticsmatters/vs-prep:2.0.0'
 
     input:
     path inputs // .sdf


### PR DESCRIPTION
Closes #34.

Moves the whole repository off the mutable `stable`/`latest` tags and onto a single immutable release tag, so the Jobs can be wiped from the Data Manager and re-loaded as one coherent, reproducible set.

### What changed

| Area | Change |
| ---- | ------ |
| `data-manager/` (8 files) | All **48** Job Definition `version` values → `'2.0.0'` (were 38 × `1.0.0`, 8 × `1.0.1`, 2 × `1.0.2`); the **46** `image.tag` values for our images → `'2.0.0'` |
| `nf-processes/` (22 files) | All **28** `container 'informaticsmatters/…'` directives → `:2.0.0` |
| 5 Dockerfiles | `FROM informaticsmatters/vs-rdkit-base:latest` → `:2.0.0` (`-fns`, `-moldb`, `-mordred`, `-oddt`, `-prep`) |
| `.github/workflows/publish-tag.yaml` | **New.** Manually dispatched, takes an `image-tag` input, calls the existing `build-all-with-push-option.yaml` with `image-push: true` |
| `.github/workflows/test.yaml` | Adds `jote --manifest manifest-moldb.yaml --dry-run` |
| `moldb/k8s-create-tables.yaml`, `README.md`, `USER_GUIDE.md`, `docker-compose.yaml` | Tag references and build docs brought in line |

### Why `2.0.0` and not `1.0.0`

`informaticsmatters/vs-prep:1.0.0`, `vs-nextflow:1.0.0` and `vs-rdock:1.0.0` already exist on Docker Hub (pushed 2021-06), and git tags `1.0.0`–`1.0.11` are already taken here. The DM treats any tag other than `latest`/`stable` as static and caches it per Kubernetes node, so republishing `1.0.0` would leave some nodes silently running 2021 code. `2.0.0` is unused across all 11 images and the base — verified against the Docker Hub tags API.

### Deliberately unchanged

- **`3dechem/silicos-it:latest`** — third-party, and `latest` is the only tag it has ever published (2017-08-15). The two silicos-it Jobs move to version `2.0.0` but keep that image tag, and stay non-reproducible. The existing explanatory comment is untouched.
- **`build.yaml`, `publish-latest.yaml`, `publish-stable.yaml`** — the `latest`/`stable` development loop still has value for the non-Nextflow images.
- `euclia/jaqpotpy-inference:1.1.0`, `informaticsmatters/rdock:2013.1`, `python:3.10.12-slim-bullseye`, `debian:bullseye` — already pinned.
- `kind-version: '2021.1'` — schema version, not a Job version.

### Known consequence

`nf-processes/` is `COPY`'d into the `vs-nextflow` image, so these tags are baked in at build time. The `latest`/`stable` `vs-nextflow` images built from `staging`/`main` will now also spawn `:2.0.0` process containers, which makes the dynamic-tag development loop incoherent for Nextflow Jobs. Accepted for now; the clean fix (a Nextflow `params` value) is a follow-up noted in #34, complicated by `nextflow.config` not being shipped in the image.

### Release sequence after merge

1. Build and push `informaticsmatters/vs-rdkit-base:2.0.0` **by hand** — five images are `FROM` it and the CI build fails without it.
2. Merge.
3. Run `publish-tag` from `main` with `image-tag: 2.0.0`; confirm all 11 images appear on Docker Hub.
4. Create and push the git tag `2.0.0`. Never move it.
5. Once the old Jobs are cleaned out of the DM, hand administrators the tag-pinned manifest URLs, e.g. `https://raw.githubusercontent.com/InformaticsMatters/virtual-screening/2.0.0/data-manager/manifest-im-virtual-screening.yaml`.

### Verification done

- `jote --dry-run` passes against **all six** manifests: fragnet-search 3/3, im-virtual-screening 32/32, silicos-it 0/0, dmpk 1/1, im-mordred 2/2, moldb 12/12. (moldb passes without `--allow-no-tests`, so it is added to CI unqualified.)
- Sweep is complete — `tag: 'stable'`, `version: '1.0.`, `:stable` under `nf-processes/`, and `vs-rdkit-base:latest` all return nothing. Counts confirmed at 48 / 46 / 2 / 28.
- `2.0.0` confirmed absent from Docker Hub for every image, including the base.
- The `#        tag: …` line in the guide comment block at `data-manager/im-virtual-screening.yaml:40` was not touched by the sweep.

**Not yet done:** no `2.0.0` image exists anywhere yet, so nothing has been run against a real `2.0.0` container. Step 1 and 3 above have to happen before an end-to-end `jote` run (particularly a Nextflow Job such as `run-rdock` or `moldb-load-library`, which is what proves the baked-in process container tags resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
