### PR TITLE
fix: give publish-latest its own workflow name

### DIFF
--- a/.github/workflows/publish-latest.yaml
+++ b/.github/workflows/publish-latest.yaml
@@ -1,8 +1,8 @@
 ---
-name: publish-stable
+name: publish-latest
 
-# Actions that take place on tags.
-# Here we build a 'stable' image, regardless of tag value.
+# Actions that take place on the 'staging' branch.
+# Here we build and push a series of 'latest' images.
 
 # -----------------
 # Control variables (GitHub Secrets)
@@ -29,7 +29,7 @@ jobs:
   call-test:
     uses: ./.github/workflows/test.yaml
 
-  call-build-without-push:
+  call-build-with-push:
     needs: call-test
     uses: ./.github/workflows/build-all-with-push-option.yaml
     secrets: inherit

--- a/.github/workflows/publish-stable.yaml
+++ b/.github/workflows/publish-stable.yaml
@@ -1,7 +1,8 @@
 ---
 name: publish-stable
 
-# Actions that take place to create a 'stabkle' image.
+# Actions that take place on the 'main' branch (and nightly).
+# Here we build and push a series of 'stable' images.
 
 # -----------------
 # Control variables (GitHub Secrets)


### PR DESCRIPTION
`publish-latest.yaml` declared `name: publish-stable`, so both publish workflows appeared under the same name in the Actions UI and API:

```
$ gh api repos/InformaticsMatters/virtual-screening/actions/workflows
publish-stable  state=active
publish-stable  state=disabled_inactivity
...
```

Two identically-named entries, one active and one disabled, with no way to tell which file each corresponds to.

### Changes

`.github/workflows/publish-latest.yaml`

- `name: publish-stable` → `name: publish-latest`
- Header comment said *"Actions that take place on tags. Here we build a 'stable' image, regardless of tag value."* — copy-pasted from `publish-stable.yaml` and wrong on both counts. It triggers on the `staging` branch and builds `latest`.
- Job key `call-build-without-push` → `call-build-with-push`; it passes `image-push: true`, so the old name said the opposite of what it does.

`.github/workflows/publish-stable.yaml`

- Fixes the `stabkle` typo in the header and names the branch it fires on.

### No behaviour change

`on:` triggers, `image-tag`, `image-push` and `secrets: inherit` are all untouched. Renaming a workflow does reset its run history in the Actions UI, which costs nothing here — both workflows currently report `total_count=0` runs.

All seven workflow names are now unique: `build`, `build-and-push`, `build-all-with-push-option`, `publish-latest`, `publish-stable`, `publish-tag`, `test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
